### PR TITLE
Document cases where F does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,35 @@ is used as a separator for specifying formatting (according to the same rules of
 
 See the `examples` directory for more examples.
 
+## Caveats
+
+`F` uses Lua's debug library to obtain at runtime the values of the variables defined in the current scope. However, this information is not always available, in which case F might return unexpected results.
+
+The first problematic situation is that `F` cannot see local variables when it is used in a tail-call position:
+
+    do
+      local g = function(x) return F'hello {x}' end
+      print(g("world")) -- prints 'hello nil' instead of 'hello world'
+    end
+
+The second problematic setting is that `F` can't see variables in outer functions when those variables are not referenced in any inner functions:
+
+    do
+      local x = "world"
+      (function()
+        print(F'hello {x}') -- prints 'hello nil' instead of 'hello world'
+      end)()
+    end
+
+One possible workaround is to pass the outer variable as an additional parameter to `F`. Although `F` ignores all arguments other than the template string, just using the outer variable is enough to cause Lua to package it into an upvalue, thus making it visible to `F`:
+
+    do
+      local x = "world"
+      (function()
+        print(F('hello {x}', x))
+      end)()
+    end
+
 ## Author
 
 Hisham Muhammad - [http://twitter.com/hisham_hm](@hisham_hm) - http://hisham.hm/

--- a/spec/F_spec.lua
+++ b/spec/F_spec.lua
@@ -3,13 +3,13 @@ describe("string interpolation", function()
 	local assert = assert
 	it("works with literals", function()
 		assert.same("foo", F'{"foo"}')
-	end)
+	end);
 	it("works with locals", function()
 		do
 			local x = "foo"
 			assert.same("foo", F'{x}')
 		end
-	end)
+	end);
 	it("works with referenced upvalues", function()
 		do
 			local x = "foo"
@@ -18,15 +18,31 @@ describe("string interpolation", function()
 				assert.same("foo", F'{x}')
 			end)()
 		end
-	end)
+	end);
+	it("works with referenced upvalues (extra argument trick)", function()
+		do
+			local x = "foo"
+			(function()
+				-- F ignores the second argument
+				-- but just referencing `x` is enough...
+				assert.same("foo", F('{x}', x))
+			end)()
+		end
+	end);
 	it("fails with unreferenced upvalues", function()
 		do
+			local x = "foo"
 			(function()
-				local x = "foo"
-				return function()
-					assert.not_same("foo", F'{x}')
-				end
-			end)()()
+				assert.not_same("foo", F'{x}')
+			end)()
+		end
+	end);
+	it("fails when F is a tail-call", function()
+		do
+			local function g(x)
+				return F'{x}'
+			end
+			assert.same('nil', g("foo"))
 		end
 	end);
 	(_VERSION == "Lua 5.1" and it or pending)("works with setfenv'd functions", function()


### PR DESCRIPTION
Namely:
- F uses unreferenced upvalues
- F is in tail-call position
