### PR TITLE
brute force handling for {{ and }}

### DIFF
--- a/F.lua
+++ b/F.lua
@@ -28,12 +28,13 @@ end
 
 local function snd(_, b) return b end
 
-F._ocb, F._ccb = '{', '}'
+-- Refer to these below as 'package.loaded.F.ocb', and the reverse of *.ccb.
+F.ocb, F.ccb = '{', '}'
 
 local function format(_, str)
    local outer_env = _ENV and (snd(scan_using(debug.getlocal, 3, "_ENV")) or snd(scan_using(debug.getupvalue, debug.getinfo(2, "f").func, "_ENV")) or _ENV) or getfenv(2)
-   local str1 = string.gsub(str:gsub("}}","{F._ccb}"),"{{","{F._ocb}")
-   return (str1:gsub("%b{}", function(block)
+   str = str:reverse():gsub('}}','}bcc.F.dedaol.egakcap{'):reverse():gsub('{{','{package.loaded.F.ocb}')
+   return (str:gsub("%b{}", function(block)
       local code, fmt = block:match("{(.*):(%%.*)}")
       code = code or block:match("{(.*)}")
       local exp_env = {}

--- a/F.lua
+++ b/F.lua
@@ -28,12 +28,9 @@ end
 
 local function snd(_, b) return b end
 
--- Refer to these below as 'package.loaded.F.ocb', and the reverse of *.ccb.
-F.ocb, F.ccb = '{', '}'
-
 local function format(_, str)
    local outer_env = _ENV and (snd(scan_using(debug.getlocal, 3, "_ENV")) or snd(scan_using(debug.getupvalue, debug.getinfo(2, "f").func, "_ENV")) or _ENV) or getfenv(2)
-   str = str:reverse():gsub('}}','}bcc.F.dedaol.egakcap{'):reverse():gsub('{{','{package.loaded.F.ocb}')
+   str = str:reverse():gsub('}}','})521(rahc.gnirts{'):reverse():gsub('{{','{string.char(123)}')
    return (str:gsub("%b{}", function(block)
       local code, fmt = block:match("{(.*):(%%.*)}")
       code = code or block:match("{(.*)}")

--- a/F.lua
+++ b/F.lua
@@ -28,9 +28,12 @@ end
 
 local function snd(_, b) return b end
 
+F._ocb, F._ccb = '{', '}'
+
 local function format(_, str)
    local outer_env = _ENV and (snd(scan_using(debug.getlocal, 3, "_ENV")) or snd(scan_using(debug.getupvalue, debug.getinfo(2, "f").func, "_ENV")) or _ENV) or getfenv(2)
-   return (str:gsub("%b{}", function(block)
+   local str1 = string.gsub(str:gsub("}}","{F._ccb}"),"{{","{F._ocb}")
+   return (str1:gsub("%b{}", function(block)
       local code, fmt = block:match("{(.*):(%%.*)}")
       code = code or block:match("{(.*)}")
       local exp_env = {}


### PR DESCRIPTION
Apparently both Python and Rust now support f-strings syntax.  They have a slightly different way to insert a literal open- or close-curly brace: They double the character in question: '{{' turns into '{', etc.  It would be nice if the Lua version of f-strings could follow what seems to be common practice now.

This PR is quite brute force.  Perhaps it can be improved.